### PR TITLE
Use URIUtils to encode URL parts in SJS

### DIFF
--- a/core/src/main/scala-js/routing/UrlEncoder.scala
+++ b/core/src/main/scala-js/routing/UrlEncoder.scala
@@ -1,0 +1,10 @@
+package routing
+
+import scala.scalajs.js.URIUtils
+
+object UrlEncoder {
+
+  private[routing] def queryEncode(s: String): String = URIUtils.encodeURI(s)
+  private[routing] def pathEncode(s: String): String = queryEncode(s).replace("+", "%20")
+
+}

--- a/core/src/main/scala-jvm/routing/UrlEncoder.scala
+++ b/core/src/main/scala-jvm/routing/UrlEncoder.scala
@@ -1,0 +1,10 @@
+package routing
+
+import java.net.URLEncoder
+
+object UrlEncoder {
+
+  private[routing] def queryEncode(s: String): String = URLEncoder.encode(s, utf8)
+  private[routing] def pathEncode(s: String): String = queryEncode(s).replace("+", "%20")
+
+}

--- a/core/src/main/scala/routing/ReverseUri.scala
+++ b/core/src/main/scala/routing/ReverseUri.scala
@@ -9,10 +9,10 @@ final case class ReverseUri(method: Method, path: ReversePath, query: ReverseQue
 
 object ReverseUri {
   private def appendQueryPair(b: StringBuilder, t: (String, Option[String])): Unit = {
-    b.append(queryUrlEncode(t._1))
+    b.append(UrlEncoder.queryEncode(t._1))
     t._2.foreach { v =>
       b.append('=')
-      b.append(queryUrlEncode(v))
+      b.append(UrlEncoder.queryEncode(v))
     }
   }
 

--- a/core/src/main/scala/routing/Route.scala
+++ b/core/src/main/scala/routing/Route.scala
@@ -34,8 +34,8 @@ abstract class Route[M <: Method, P] extends RouteMethods[M, P] { self =>
     pathParts(params).foreach { p =>
       b.append('/')
       p match {
-        case m: PathPart.Multi => b.append(m.show.split('/').map(pathUrlEncode).mkString("/"))
-        case s: PathPart.Single => b.append(pathUrlEncode(s.show))
+        case m: PathPart.Multi => b.append(m.show.split('/').map(UrlEncoder.pathEncode).mkString("/"))
+        case s: PathPart.Single => b.append(UrlEncoder.pathEncode(s.show))
       }
     }
     b.toString

--- a/core/src/main/scala/routing/package.scala
+++ b/core/src/main/scala/routing/package.scala
@@ -1,4 +1,3 @@
-import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
 
 package object routing {
@@ -20,7 +19,4 @@ package object routing {
   def optionalQueryParam[A](key: String): (String, Option[Option[A]]) = key -> None
 
   private[routing] val utf8 = UTF_8.name()
-
-  private[routing] def queryUrlEncode(s: String): String = URLEncoder.encode(s, utf8)
-  private[routing] def pathUrlEncode(s: String): String = queryUrlEncode(s).replace("+", "%20")
 }


### PR DESCRIPTION
Since `java.net.URLEncoder` is not available on ScalaJS, and I could not
find a suitable replacement which would not result in a new dependency,
I separated the affected code into separate source directories. The SJS
code now uses JavaScript `URIUtils`.