### PR TITLE
Deprecate `showFromCatsShow`, clean up build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,7 @@ jobs:
       - name: Build docs
         if: matrix.java == 'temurin@25'
         run: sbt mdoc
+
+      - name: Check binary compatibility
+        if: matrix.java == 'temurin@25'
+        run: sbt mimaReportBinaryIssues

--- a/bench/src/main/scala/routing/bench/Http4sBenchmark.scala
+++ b/bench/src/main/scala/routing/bench/Http4sBenchmark.scala
@@ -36,8 +36,7 @@ object http4sHelper extends BenchmarkHelper[Request[IO], Request[IO] => IO[Respo
     runIO(routes.run(request).value.flatMap(_.get.as[String]))
 }
 
-class Http4sBenchmark_0_23 { // 0.23
-class Http4sBenchmark_1_0_0_M46 { // 1.0.0-M46
+class Http4sBenchmark {
   import http4sHelper._
 
   @Benchmark def http4s: String = run(http4sService)

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import java.io.File
-import routing.currentVersion
 import routing.Build._
 import scala.sys.process._
 

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ def isJava(v: Int) = s"matrix.java == '${javaVersions.find(_.version == v.toStri
 ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Run(List("sbt test"), name = Some("Build project")),
   WorkflowStep.Run(List("sbt mdoc"), name = Some("Build docs"), cond = Some(isJava(25))),
+  WorkflowStep.Run(List("sbt mimaReportBinaryIssues"), name = Some("Check binary compatibility"), cond = Some(isJava(25))),
 )
 
 lazy val core = simpleProj(projectMatrix.in(file("core")), "core", List(

--- a/core/src/main/scala/routing/util/Show.scala
+++ b/core/src/main/scala/routing/util/Show.scala
@@ -18,6 +18,7 @@ private[routing] object CatsShow {
 }
 
 trait LPShow {
+  @deprecated("Define instances of routing.util.Show explicitly", "5.1.0")
   final implicit def showFromCatsShow[F[_], A](implicit ev: GetTC[CatsShow, F], F: F[A]): Show[A] = {
     import ev._
     Show.show(F.show(_))

--- a/example/src/main/scala/routing/example/App.scala
+++ b/example/src/main/scala/routing/example/App.scala
@@ -5,12 +5,10 @@ import com.comcast.ip4s.*
 import org.http4s.ember.server.EmberServerBuilder
 
 object App extends IOApp {
-  // ++ 1.0.0-M46
   import org.typelevel.log4cats.LoggerFactory
   import org.typelevel.log4cats.noop.NoOpFactory
 
-  private implicit val loggerFactory: LoggerFactory[IO] = NoOpFactory[IO]
-  // -- 1.0.0-M46
+  implicit val loggerFactory: LoggerFactory[IO] = NoOpFactory[IO]
 
   override def run(args: List[String]): IO[ExitCode] =
     EmberServerBuilder.default[IO]

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -10,6 +10,7 @@ import sbtprojectmatrix.ProjectMatrixPlugin.autoImport._
 import scala.sys.process._
 
 object Build {
+  lazy val currentVersion = "5.0.0"
   lazy val scalaVersions = Seq("2.13.18", "3.3.7")
   lazy val latestScalaV = scalaVersions.find(_.startsWith("3.")).get
   lazy val kindProjector = compilerPlugin("org.typelevel" % "kind-projector" % "0.13.4" cross CrossVersion.full)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,5 +1,6 @@
 package routing
 
+import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport.{mimaFailOnNoPrevious, mimaPreviousArtifacts}
 import java.io.File
 import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 import sbt._
@@ -87,18 +88,25 @@ object Build {
     publish / skip := true,
     Compile / packageDoc / publishArtifact := false,
     packageDoc / publishArtifact := false,
-    Compile / doc / sources := Seq()
+    Compile / doc / sources := Seq(),
   )
 
   val publishSettings = Seq(
     licenses += License.Apache2,
     publish / skip := false,
     publishTo := Some("BondLink S3".at("s3://bondlink-maven-repo")),
+    resolvers += "bondlink-maven-repo" at "https://maven.bondlink-cdn.com",
+    mimaPreviousArtifacts := Set(organization.value %%% (moduleName.value match {
+      case s if s.startsWith(s"routing-http4s_$http4sV1Milestone") => s"routing-http4s_${http4sV1Milestone.toLowerCase}44"
+      case s => s
+    }) % "5.0.0"),
+    mimaFailOnNoPrevious := false,
   )
 
   val noPublishSettings = Seq(
     publish := {},
     publishLocal := {},
+    mimaFailOnNoPrevious := false,
   )
 
   sealed abstract class Platform(val s: String)
@@ -194,7 +202,7 @@ object Build {
       axesProj(matrix, nme, axes)(
         platforms,
         axis => platform => proj => settings(axis)(platform)(defaultSettings(axis)(platform)(proj)).settings(
-          moduleName := s"${name.value}_${suffix(axis).toLowerCase}",
+          moduleName := s"${name.value}_${suffix(axis)}",
           Compile / sources := {
             val srcs = (Compile / sources).value
             val srcManaged = (Compile / sourceManaged).value / "parsed"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -162,12 +162,10 @@ object Build {
     nme: String,
     platforms: List[Platform],
     extraSettings: ProjSettings = _ => identity,
-    modScalaVersions: Platform => Seq[String] => Seq[String] = _ => identity,
-    includeNative: Boolean = false
   ) =
     platformAxes(platforms).foldLeft(baseProj(matrix, nme)) { case (acc, (platform, axis)) =>
       acc.customRow(
-        scalaVersions = modScalaVersions(platform)(scalaVersions),
+        scalaVersions = scalaVersions,
         axisValues = Seq(axis),
         projSettings(extraSettings)(platform),
       )
@@ -176,13 +174,12 @@ object Build {
   def axesProj[V](matrix: ProjectMatrix, nme: String, axes: List[V])(
     platforms: V => List[Platform],
     extraSettings: V => ProjSettings,
-    modScalaVersions: V => Platform => Seq[String] => Seq[String] = (_: V) => (_: Platform) => identity _,
   )(implicit va: V => VirtualAxis) =
     axes
       .flatMap(a => platformAxes(platforms(a)).map(a -> _))
       .foldLeft(baseProj(matrix, nme)) { case (acc, (versionAxis, (platform, platformAxis))) =>
         acc.customRow(
-          scalaVersions = modScalaVersions(versionAxis)(platform)(scalaVersions),
+          scalaVersions = scalaVersions,
           axisValues = Seq(va(versionAxis), platformAxis),
           projSettings(extraSettings(versionAxis))(platform),
         )
@@ -192,17 +189,14 @@ object Build {
 
   case class LibAxesProj[V](axes: List[V])(
     suffix: V => String,
-    defaultSettings: V => ProjSettings,
     defaultPlatforms: V => List[Platform],
-    defaultModScalaVersions: V => Platform => Seq[String] => Seq[String],
   ) {
     def apply(matrix: ProjectMatrix, nme: String, platforms: V => List[Platform] = defaultPlatforms)(
       settings: V => ProjSettings,
-      modScalaVersions: V => Platform => Seq[String] => Seq[String] = (_: V) => (_: Platform) => identity[Seq[String]],
     )(implicit va: V => VirtualAxis) =
       axesProj(matrix, nme, axes)(
         platforms,
-        axis => platform => proj => settings(axis)(platform)(defaultSettings(axis)(platform)(proj)).settings(
+        axis => platform => proj => settings(axis)(platform)(proj).settings(
           moduleName := s"${name.value}_${suffix(axis)}",
           Compile / sources := {
             val srcs = (Compile / sources).value
@@ -221,36 +215,16 @@ object Build {
             }
           },
         ),
-        modScalaVersions = axis => platform =>
-          defaultModScalaVersions(axis)(platform).andThen(modScalaVersions(axis)(platform)),
       )
   }
 
   val defaultHttp4sPlatforms = (_: Http4sAxis.Value) match {
     case Http4sAxis.v0_23 | Http4sAxis.v1_0_0_M46 => List(Platform.Jvm, Platform.Js)
   }
-  val defaultHttp4sScalaVersions = (axis: Http4sAxis.Value) => (_: Platform) => axis match {
-    case Http4sAxis.v0_23 | Http4sAxis.v1_0_0_M46 => identity[Seq[String]] _
-  }
-
-  lazy val http4sProj = LibAxesProj(Http4sAxis.all)(
-    _.suffix,
-    _ => _ => identity[Project],
-    defaultHttp4sPlatforms,
-    defaultHttp4sScalaVersions,
-  )
+  lazy val http4sProj = LibAxesProj(Http4sAxis.all)(_.suffix, defaultHttp4sPlatforms)
 
   val defaultPlayPlatforms = (_: PlayAxis.Value) => List(Platform.Jvm)
-  val defaultPlayScalaVersions = (axis: PlayAxis.Value) => (_: Platform) => axis match {
-    case PlayAxis.v2_9 | PlayAxis.v3_0 => identity[Seq[String]] _
-  }
-
-  lazy val playProj = LibAxesProj(PlayAxis.all)(
-    _.suffix,
-    _ => _ => identity[Project],
-    defaultPlayPlatforms,
-    defaultPlayScalaVersions,
-  )
+  lazy val playProj = LibAxesProj(PlayAxis.all)(_.suffix, defaultPlayPlatforms)
 
   val scalacheckVersion = "1.19.0"
   val scalacheckDep = Def.setting("org.scalacheck" %%% "scalacheck" % scalacheckVersion)
@@ -304,8 +278,6 @@ object Build {
 
     lazy val all = values.toList
   }
-
-  def isHttp4sV1Milestone(version: String): Boolean = version.startsWith(http4sV1Milestone)
 
   def circeDep(proj: String) = Def.setting("io.circe" %%% s"circe-$proj" % "0.14.15")
 }

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,3 +1,0 @@
-package object routing {
-  val currentVersion = "5.0.0"
-}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
 addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.11.0")
 addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.23.0")
 addSbtPlugin("com.github.sbt" % "sbt-github-actions" % "0.30.0")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.5")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.21.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12")


### PR DESCRIPTION
`showFromCatsShow` uses the [No More Orphans](https://blog.7mind.io/no-more-orphans.html) trick to provide an instance of `routing.util.Show` in terms of an existing instance of `cats.Show`, while keeping `cats-core` as an optional dependency of `routing-core`. This means that downstream users could depend on `routing-core` without pulling in `cats-core`, but if `cats-core` was also on the classpath then the `showFromCatsShow` implicit would take effect.

The pattern is a little hacky though, and won't work anymore in Scala 3.10, so it's better to just require users to define their own explicit instances of `routing.util.Show`.

This also cleans up unused parts of the build to help simplify it.